### PR TITLE
fix freeze when input globals as a large list in debug mode

### DIFF
--- a/R/globals.R
+++ b/R/globals.R
@@ -40,7 +40,7 @@ getGlobalsAndPackagesXApply <- function(FUN, args = NULL, MoreArgs = NULL, envir
     globals <- globalsByName(globals, envir = envir, mustExist = FALSE)
   } else if (is.list(globals)) {
     names <- names(globals)
-    if (debug) mdebugf(" - future.globals: <name-value list> with names %s", commaq(globals))
+    if (debug) mdebugf(" - future.globals: <name-value list> with names %s", commaq(names(globals)))
     if (length(globals) > 0 && is.null(names)) {
       stop("Invalid argument 'future.globals'. All globals must be named")
     }


### PR DESCRIPTION
When the `future.globals` is a list, and options(future.apply.debug = TRUE), current implement will make the R process stick due to the convertion of a list of any objects into a character 